### PR TITLE
Spec file rework for 1.3

### DIFF
--- a/rpm/crypto-sdcard.spec
+++ b/rpm/crypto-sdcard.spec
@@ -4,8 +4,8 @@ Version:       1.3.1
 Since v1.3.1, the release version consists of two or three fields, separated by a dot ("."):
 - The first field must contain a natural number greater than zero.  This number is usually "1",
   because the spec file is part of the tarball and hence any change to the spec file (as to any
-  other file of this project, which is packaged for and deployed by RPM) shall cause a version
-  increase of a git tag and new tarball crated later.
+  other file of this project, which is packaged for and deployed by RPM) shall trigger a version
+  increase of the next git tag and new tarball created later.
   This number may be prefixed by one of {alpha,beta,stable}, e.g. "alpha13".
 - The second field indicates the minimal required SailfishOS version A.B.C.X in the format "sfosABC";
   the fourth field of a SailfishOS version ("X") is neither depended upon or denoted.

--- a/rpm/crypto-sdcard.spec
+++ b/rpm/crypto-sdcard.spec
@@ -1,21 +1,27 @@
 Name:          crypto-sdcard
 Summary:       Configuration files for unlocking and mounting encrypted SD-cards automatically
-Version:       1.2.5
-# Stop evaluating the Release tag content (only set it) and cease including it in git tags since v1.2.0, 
-# in order to satisfy OBS' git_tar.  Consequently switch to a three field semantic versioning scheme for
-# releases and their git tags.
-# Hence any changes to the spec file now always trigger an increase of the bug fix release number, i.e.
-# the third field of the Version.
-# But the Release tag is now merely used to monotonically count up through all releases (starting from 1).
-# Note that no other release identifiers shall be used.
-Release:       46
+Version:       1.3.1
+Since v1.3.1, the release version consists of two or three fields, separated by a dot ("."):
+- The first field must contain a natural number greater than zero.  This number is usually "1",
+  because the spec file is part of the tarball and hence any change to the spec file (as to any
+  other file of this project, which is packaged for and deployed by RPM) shall cause a version
+  increase of a git tag and new tarball crated later.
+  This number may be prefixed by one of {alpha,beta,stable}, e.g. "alpha13".
+- The second field indicates the minimal required SailfishOS version A.B.C.X in the format "sfosABC";
+  the fourth field of a SailfishOS version ("X") is neither depended upon or denoted.
+- Additional information may be appended to the second field prefixed by a "+", e.g. "+qcrypto" here
+  or "+special+something".
+- An optional third field might be used by downstream packagers, who alter the package but want to
+  retain the exact version number.  It shall consist of the packager's name appended with a natural 
+  number greater than zero, e.g "joe8".
+Release:       1.sfosABC
 Group:         System/Base
 Distribution:  SailfishOS
 Vendor:        olf
 Packager:      olf
 License:       MIT
 URL:           https://github.com/Olf0/%{name}
-Source:        https://github.com/Olf0/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+Source:        https://github.com/Olf0/%{name}/archive/%{version}-%{release}/%{name}-%{version}-%{release}.tar.gz
 # rpmbuild (as of v4.14.1) handles the Icon tag awkwardly and in contrast to the Source tag(s):
 # It only accepts a GIF or XPM file (a path is stripped to its basename) in the SOURCE directory
 # (but not in the tarball)!  Successfully tested GIF89a and XPMv3, but an XPM icon results in
@@ -39,7 +45,7 @@ Conflicts:     crypto-sdcard_sbj
 "Key"-file naming scheme: /etc/%{name}/crypto_luks_<UUID>.key rsp. /etc/%{name}/crypto_plain_<device-name>.key
 
 %prep
-%setup
+%setup -n %{name}-%{version}-%{release}
 
 %build
 


### PR DESCRIPTION
a. Release version format
Since v1.3.1, the release version consists of two or three fields, separated by a dot ("."):
- The first field must contain a natural number greater than zero.  This number is usually "1", because the spec file is part of the tarball and hence any change to the spec file (as to any other file of this project, which is packaged for and deployed by RPM) shall  trigger a version increase of the next git tag and new tarball created later.
  This number may be prefixed by one of {alpha,beta,stable}, e.g. "alpha13".
- The second field indicates the minimal required SailfishOS version A.B.C.X in the format "sfosABC"; the fourth field of a SailfishOS version ("X") is neither depended upon or denoted.
- Additional information may be appended to the second field prefixed by a "+", e.g. "+qcrypto" here or "+special+something".
- An optional third field might be used by downstream packagers, who alter the package but want to retain the exact version number.  It shall consist of the packager's name appended with a natural number greater than zero, e.g "joe8".

b. Git workflow
1. Restructured Git workflow to acomodate releases for different SailfishOS versions:
   - Changes common to all SailfishOS version specific release branches are first committed to the "master" branch and then pushed to each release branch.
   - Changes specific to one (or multiple, but not all) release branches are directly committed to the(se) branch(es).
   - The SailfishOS version specific release branches are named "sfosABC" denoting their minimal required SailfishOS version A.B.C.X; the fourth field of a SailfishOS version ("X") is neither depended upon or denoted.
   - The "master" branch is not in a buildable, deliberately.
2. Git tags for releases are now named "%{version}-%{release}", consequently the tarball and (S)RPM releases are both (!) named "%{name}-%{version}-%{release}" (plus their file extension).