### PR TITLE
No cryptsetup.target extant on SFOS 2.2.1+

### DIFF
--- a/systemd/system/cryptosd-luks@.service
+++ b/systemd/system/cryptosd-luks@.service
@@ -3,8 +3,7 @@ Description=Open DM-Crypt LUKS on SD-card %I
 Documentation=https://github.com/Olf0/crypto-sdcard
 After=systemd-udevd.service dev-%i.device
 BindsTo=dev-%i.device
-PartOf=cryptsetup.target
-Conflicts=actdead.target factory-test.target
+Conflicts=umount.target actdead.target factory-test.target
 AssertFileNotEmpty=/etc/crypto-sdcard/%I.key
 
 [Service]

--- a/systemd/system/cryptosd-plain@.service
+++ b/systemd/system/cryptosd-plain@.service
@@ -3,8 +3,7 @@ Description=Open DM-Crypt "plain" on SD-card %I
 Documentation=https://github.com/Olf0/crypto-sdcard
 After=systemd-udevd.service dev-%i.device
 BindsTo=dev-%i.device
-PartOf=cryptsetup.target
-Conflicts=actdead.target factory-test.target
+Conflicts=umount.target actdead.target factory-test.target
 AssertFileNotEmpty=/etc/crypto-sdcard/%I.key
 
 [Service]

--- a/systemd/system/mount-cryptosd-luks@.service
+++ b/systemd/system/mount-cryptosd-luks@.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Mount LUKS encrypted SD-card (%I) with udisks
 Documentation=https://github.com/Olf0/crypto-sdcard
-After=udisks2.service cryptosd-luks@%i.service cryptsetup.target dev-mapper-%i.device start-user-session.service
-BindsTo=cryptsetup.target dev-mapper-%i.device
+After=udisks2.service cryptosd-luks@%i.service dev-mapper-%i.device start-user-session.service
+BindsTo=dev-mapper-%i.device
 Requires=udisks2.service cryptosd-luks@%i.service
 # Allow for rescue.target and conflict with umount.target (see
 # man 7 systemd.special; needed explicitly for the new ExecStopPost

--- a/systemd/system/mount-cryptosd-plain@.service
+++ b/systemd/system/mount-cryptosd-plain@.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Mount "plain" encrypted SD-card (%I) with udisks
 Documentation=https://github.com/Olf0/crypto-sdcard
-After=udisks2.service cryptosd-plain@%i.service cryptsetup.target dev-mapper-%i.device start-user-session.service
-BindsTo=cryptsetup.target dev-mapper-%i.device
+After=udisks2.service cryptosd-plain@%i.service dev-mapper-%i.device start-user-session.service
+BindsTo=dev-mapper-%i.device
 Requires=udisks2.service cryptosd-plain@%i.service
 # Allow for rescue.target and conflict with umount.target (see
 # man 7 systemd.special; needed explicitly for the new ExecStopPost


### PR DESCRIPTION
No cryptsetup.target extant on SFOS 2.2.1+